### PR TITLE
Fix bug that causes "Undefined metadataName"

### DIFF
--- a/index.js
+++ b/index.js
@@ -403,7 +403,7 @@ class CashID {
       let missingFields = [];
 
       // Loop over the required metadata fields.
-      for (const metadataValue in parsedRequest['parameters']['required']) {
+      for (const metadataName in parsedRequest['parameters']['required']) {
         // If the field was required && missing from the response..
         if (
           metadataValue &&


### PR DESCRIPTION
I think this was a typo during the conversion from the PHP Library (metadataValue vs metadataName).
The validateRequest function would fail due to the bug mentioned in the subject. This appears to fix it.